### PR TITLE
Fix swapped assert

### DIFF
--- a/OldTests/src/test/java/com/tle/webtests/test/contribute/MetadataMappingTest.java
+++ b/OldTests/src/test/java/com/tle/webtests/test/contribute/MetadataMappingTest.java
@@ -71,8 +71,8 @@ public class MetadataMappingTest extends AbstractCleanupTest
 		assertNode(x, "RepeatingReplace", "Vocabulary");
 		assertNode(x, "RepeatingReplace", "Travel");
 
-		assertNode(x, "HTML", "html description");
-		assertNoNode(x, "HTML", text);
+		assertNode(x, "HTML", text);
+		assertNoNode(x, "HTML", "html description");
 		assertNode(x, "Literal", "Fixed value");
 		assertNoNode(x, "Literal", text);
 	}

--- a/OldTests/src/test/java/com/tle/webtests/test/contribute/MetadataMappingTest.java
+++ b/OldTests/src/test/java/com/tle/webtests/test/contribute/MetadataMappingTest.java
@@ -72,7 +72,6 @@ public class MetadataMappingTest extends AbstractCleanupTest
 		assertNode(x, "RepeatingReplace", "Travel");
 
 		assertNode(x, "HTML", text);
-		assertNoNode(x, "HTML", "html description");
 		assertNode(x, "Literal", "Fixed value");
 		assertNoNode(x, "Literal", text);
 	}


### PR DESCRIPTION
Test was checking for a string within the XML node that could not
possibly exist as it was never set, and asserting that correct value
was NOT there. These two checks should be swapped.