### PR TITLE
Swap order of date picker operations

### DIFF
--- a/Tests/src/main/java/com/tle/webtests/pageobject/generic/component/Calendar.java
+++ b/Tests/src/main/java/com/tle/webtests/pageobject/generic/component/Calendar.java
@@ -73,8 +73,8 @@ public class Calendar extends AbstractPage<Calendar>
 		WebElement imgElem = getField().findElement(By.xpath("following-sibling::img"));
 		imgElem.click();
 		waitForElement(By.id("ui-datepicker-div"));
-		clickMonthYear("month", cal.get(java.util.Calendar.MONTH));
-		clickMonthYear("year", cal.get(java.util.Calendar.YEAR));
+        clickMonthYear("year", cal.get(java.util.Calendar.YEAR));
+        clickMonthYear("month", cal.get(java.util.Calendar.MONTH));
 
 		String dayXpath = "id(''ui-datepicker-div'')/table[@class=''ui-datepicker-calendar'']/tbody/tr/td/a[text()=''{0}'']";
 		String day = MessageFormat.format(dayXpath, Integer.toString(cal.get(java.util.Calendar.DAY_OF_MONTH)));

--- a/Tests/src/main/java/com/tle/webtests/pageobject/generic/component/Calendar.java
+++ b/Tests/src/main/java/com/tle/webtests/pageobject/generic/component/Calendar.java
@@ -73,8 +73,8 @@ public class Calendar extends AbstractPage<Calendar>
 		WebElement imgElem = getField().findElement(By.xpath("following-sibling::img"));
 		imgElem.click();
 		waitForElement(By.id("ui-datepicker-div"));
-        clickMonthYear("year", cal.get(java.util.Calendar.YEAR));
-        clickMonthYear("month", cal.get(java.util.Calendar.MONTH));
+		clickMonthYear("year", cal.get(java.util.Calendar.YEAR));
+		clickMonthYear("month", cal.get(java.util.Calendar.MONTH));
 
 		String dayXpath = "id(''ui-datepicker-div'')/table[@class=''ui-datepicker-calendar'']/tbody/tr/td/a[text()=''{0}'']";
 		String day = MessageFormat.format(dayXpath, Integer.toString(cal.get(java.util.Calendar.DAY_OF_MONTH)));


### PR DESCRIPTION
Currently, date picker click operations selects month before year. This
is an issue when the until date is the following year (I.E if the test
is run on New Year's Eve) as selecting an earlier month of the current
year is disabled. Selecting the year first ensures that this does not
occur.