### PR TITLE
Autotest for "Login Screen Notice"

### DIFF
--- a/OldTests/src/test/java/com/tle/webtests/test/users/LoginSettingsTest.java
+++ b/OldTests/src/test/java/com/tle/webtests/test/users/LoginSettingsTest.java
@@ -41,7 +41,6 @@ public class LoginSettingsTest extends AbstractSessionTest
 		lsp.setDisableAutoLogin(true);
 		lsp.setDoNotStoreDrm(true);
 		lsp.setDisallowUserEdit(true);
-		lsp.setNotice(LOGIN_NOTICE);
 
 		// Save
 		lsp.saveFailure();

--- a/Tests/src/main/java/com/tle/webtests/pageobject/settings/LoginSettingsPage.java
+++ b/Tests/src/main/java/com/tle/webtests/pageobject/settings/LoginSettingsPage.java
@@ -40,9 +40,6 @@ public class LoginSettingsPage extends AbstractPage<LoginSettingsPage>
 	@FindBy(id = "_selectUserDialog_opener")
 	private WebElement selectUser;
 
-	@FindBy(id = "_lnf")
-	private WebElement loginNotice;
-
 	@FindBy(id = "_saveButton")
 	private WebElement save;
 	@FindBy(id = "selecteduser")
@@ -124,13 +121,6 @@ public class LoginSettingsPage extends AbstractPage<LoginSettingsPage>
 		{
 			drmCheck.click();
 		}
-		return get();
-	}
-
-	public LoginSettingsPage setNotice(String notice)
-	{
-		loginNotice.clear();
-		loginNotice.sendKeys(notice);
 		return get();
 	}
 

--- a/Tests/src/test/scala/equellatests/browserpage/CommonXPath.scala
+++ b/Tests/src/test/scala/equellatests/browserpage/CommonXPath.scala
@@ -6,5 +6,7 @@ object CommonXPath  {
 
   def buttonWithText(t: String) : By = By.xpath(s".//button[normalize-space(text()) = ${BrowserPage.quoteXPath(t)}]")
 
-  def pageTitle(title: String) : By = By.xpath("id('header-inner')/div[text()="+BrowserPage.quoteXPath(title)+"]")
+  def pageTitle(title: String) : By = By.xpath("id('header-inner')/div[text()="+BrowserPage.quoteXPath(title)+"]")  //for pages in the old UI
+
+  def newPageTitle(title: String) : By = By.xpath("//header/div/div/h1")  //for pages in the new UI
 }

--- a/Tests/src/test/scala/equellatests/browserpage/NewTitledPage.scala
+++ b/Tests/src/test/scala/equellatests/browserpage/NewTitledPage.scala
@@ -1,10 +1,12 @@
 package equellatests.browserpage
 import org.openqa.selenium.By
+
 abstract class NewTitledPage(title: String, urlPath: String) extends LoadablePage{
   override def load(): this.type = {
     driver.get(ctx.getBaseUrl+urlPath)
     get()
   }
+
   override def pageBy : By = CommonXPath.newPageTitle(title)
 
 }

--- a/Tests/src/test/scala/equellatests/browserpage/NewTitledPage.scala
+++ b/Tests/src/test/scala/equellatests/browserpage/NewTitledPage.scala
@@ -1,0 +1,10 @@
+package equellatests.browserpage
+import org.openqa.selenium.By
+abstract class NewTitledPage(title: String, urlPath: String) extends LoadablePage{
+  override def load(): this.type = {
+    driver.get(ctx.getBaseUrl+urlPath)
+    get()
+  }
+  override def pageBy : By = CommonXPath.newPageTitle(title)
+
+}

--- a/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -1,28 +1,29 @@
 package equellatests.pages
 
 import com.tle.webtests.framework.PageContext
+import com.tle.webtests.pageobject.ExpectedConditions2
 import equellatests.browserpage.NewTitledPage
 import org.openqa.selenium.{Keys, WebElement}
 
 case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice Editor", "page/loginconfiguration") {
 
-  def preNoticeApplyButton:WebElement = findElementById("preApplyButton")
+  private def preNoticeApplyButton:WebElement = findElementById("preApplyButton")
 
-  def preNoticeClearButton:WebElement = findElementById("preClearButton")
+  private def preNoticeClearButton:WebElement = findElementById("preClearButton")
 
-  def preNoticeField:WebElement = findElementById("preNoticeField")
+  private def preNoticeField:WebElement = findElementById("preNoticeField")
 
-  def postNoticeApplyButton:WebElement = findElementById("postApplyButton")
+  private def postNoticeApplyButton:WebElement = findElementById("postApplyButton")
 
-  def postNoticeClearButton:WebElement = findElementById("postClearButton")
+  private def postNoticeClearButton:WebElement = findElementById("postClearButton")
 
-  def postNoticeField:WebElement = findElementById("postNoticeField")
+  private def postNoticeField:WebElement = findElementById("postNoticeField")
 
-  def preTab:WebElement = findElementById("preTab")
+  private def preTab:WebElement = findElementById("preTab")
 
-  def postTab:WebElement = findElementById("postTab")
+  private def postTab:WebElement = findElementById("postTab")
 
-  def clearOkButton:WebElement = findElementById("okToClear")
+  private def clearOkButton:WebElement = findElementById("okToClear")
 
   def clickPreApply(): Unit = {
     this.preNoticeApplyButton.click()
@@ -70,5 +71,9 @@ case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice
   def getPostNoticeFieldContents:String = {
     postNoticeField.getText
   }
+  def pageUpdateExpectation = ExpectedConditions2.presenceOfElement(preNoticeField)
 
+  def waitForLoad(): Unit = {
+    waitFor(pageUpdateExpectation)
+  }
 }

--- a/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -1,0 +1,24 @@
+package equellatests.pages
+
+import com.tle.webtests.framework.PageContext
+import equellatests.browserpage.NewTitledPage
+import org.openqa.selenium.{Keys, WebElement}
+
+case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice Editor", "page/loginconfiguration") {
+
+  def applyButton:WebElement = findElementById("applyButton")
+
+  def noticeField:WebElement = findElementById("noticeField")
+
+  def clickApply(): Unit = {
+    this.applyButton.click()
+  }
+  def populateNoticeField(notice:String): Unit = {
+    noticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
+    noticeField.sendKeys(Keys.DELETE)
+    noticeField.sendKeys(notice)
+  }
+  def getNoticeField:String = {
+    noticeField.getText
+  }
+}

--- a/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -13,12 +13,15 @@ case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice
   def clickApply(): Unit = {
     this.applyButton.click()
   }
+
   def populateNoticeField(notice:String): Unit = {
     noticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
     noticeField.sendKeys(Keys.DELETE)
     noticeField.sendKeys(notice)
   }
-  def getNoticeField:String = {
+
+  def getNoticeFieldContents:String = {
     noticeField.getText
   }
+
 }

--- a/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -3,7 +3,8 @@ package equellatests.pages
 import com.tle.webtests.framework.PageContext
 import com.tle.webtests.pageobject.ExpectedConditions2
 import equellatests.browserpage.NewTitledPage
-import org.openqa.selenium.{Keys, WebElement}
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.{By, Keys, WebElement}
 
 case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice Editor", "page/loginconfiguration") {
 
@@ -25,55 +26,67 @@ case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice
 
   private def clearOkButton:WebElement = findElementById("okToClear")
 
-  def clickPreApply(): Unit = {
-    this.preNoticeApplyButton.click()
-  }
-
-  def clickPreClear(): Unit = {
-    this.preNoticeClearButton.click()
-    this.clearOkButton.click()
-  }
-
-  def populatePreNoticeField(notice:String): Unit = {
-
+  private def populatePreNoticeField(notice:String): Unit = {
     preNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
     preNoticeField.sendKeys(Keys.DELETE)
     preNoticeField.sendKeys(notice)
   }
+  
+  private def waitForSnackBar(content:String): Unit = {
+    waitFor(ExpectedConditions.textToBePresentInElementLocated(By.id("client-snackbar"), content))
+  }
 
+  private def waitForPostTab(): Unit = {
+    waitFor(ExpectedConditions2.presenceOfElement(postNoticeField))
+  }
+
+  def setPreLoginNotice(notice:String): Unit = {
+    populatePreNoticeField(notice)
+    preNoticeApplyButton.click()
+    waitForSnackBar("Login notice saved successfully.")
+  }
+  
+  def clearPreLoginNotice(): Unit = {
+    preNoticeClearButton.click()
+    waitFor(ExpectedConditions2.presenceOfElement(clearOkButton))
+    clearOkButton.click()
+    waitForSnackBar("Login notice cleared successfully.")
+  }
+  
   def getPreNoticeFieldContents:String = {
     preNoticeField.getText
   }
-  
-  def clickPostApply(): Unit = {
-    this.postNoticeApplyButton.click()
+
+  def setPostLoginNotice(notice:String): Unit = {
+    gotoPostNoticeTab()
+    populatePostNoticeField(notice)
+    postNoticeApplyButton.click()
+    waitForSnackBar("Login notice saved successfully.")
   }
 
-  def clickPostClear(): Unit = {
-    this.postNoticeClearButton.click()
-    this.clearOkButton.click()
+  def clearPostLoginNotice(): Unit = {
+    gotoPostNoticeTab()
+    postNoticeClearButton.click()
+    waitFor(ExpectedConditions2.presenceOfElement(clearOkButton))
+    clearOkButton.click()
+    waitForSnackBar("Login notice cleared successfully.")
   }
 
-  def clickPreTab(): Unit = {
-    this.preTab.click()
+  def getPostNoticeFieldContents:String = {
+    gotoPostNoticeTab()
+    postNoticeField.getText
   }
 
-  def clickPostTab(): Unit = {
+  def gotoPostNoticeTab(): Unit = {
     this.postTab.click()
+    waitForPostTab()
   }
 
   def populatePostNoticeField(notice:String): Unit = {
+    gotoPostNoticeTab()
     postNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
     postNoticeField.sendKeys(Keys.DELETE)
     postNoticeField.sendKeys(notice)
   }
 
-  def getPostNoticeFieldContents:String = {
-    postNoticeField.getText
-  }
-  def pageUpdateExpectation = ExpectedConditions2.presenceOfElement(preNoticeField)
-
-  def waitForLoad(): Unit = {
-    waitFor(pageUpdateExpectation)
-  }
 }

--- a/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -6,22 +6,52 @@ import org.openqa.selenium.{Keys, WebElement}
 
 case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice Editor", "page/loginconfiguration") {
 
-  def applyButton:WebElement = findElementById("applyButton")
+  def preNoticeApplyButton:WebElement = findElementById("preApplyButton")
 
-  def noticeField:WebElement = findElementById("noticeField")
+  def preNoticeDeleteButton:WebElement = findElementById("preDeleteButton")
 
-  def clickApply(): Unit = {
-    this.applyButton.click()
+  def preNoticeField:WebElement = findElementById("preNoticeField")
+
+  def postNoticeApplyButton:WebElement = findElementById("postApplyButton")
+
+  def postNoticeDeleteButton:WebElement = findElementById("postDeleteButton")
+
+  def postNoticeField:WebElement = findElementById("postNoticeField")
+  
+  def clickPreApply(): Unit = {
+    this.preNoticeApplyButton.click()
   }
 
-  def populateNoticeField(notice:String): Unit = {
-    noticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
-    noticeField.sendKeys(Keys.DELETE)
-    noticeField.sendKeys(notice)
+  def clickPreDelete(): Unit = {
+    this.preNoticeDeleteButton.click()
   }
 
-  def getNoticeFieldContents:String = {
-    noticeField.getText
+  def populatePreNoticeField(notice:String): Unit = {
+
+    preNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
+    preNoticeField.sendKeys(Keys.DELETE)
+    preNoticeField.sendKeys(notice)
   }
 
+  def getPreNoticeFieldContents:String = {
+    preNoticeField.getText
+  }
+  
+  def clickPostApply(): Unit = {
+    this.postNoticeApplyButton.click()
+  }
+
+  def clickPostDelete(): Unit = {
+    this.postNoticeDeleteButton.click()
+  }
+
+  def populatePostNoticeField(notice:String): Unit = {
+    postNoticeField.sendKeys(Keys.chord(Keys.CONTROL, "a"))
+    postNoticeField.sendKeys(Keys.DELETE)
+    postNoticeField.sendKeys(notice)
+  }
+
+  def getPostNoticeFieldContents:String = {
+    postNoticeField.getText
+  }
 }

--- a/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginNoticePage.scala
@@ -8,22 +8,29 @@ case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice
 
   def preNoticeApplyButton:WebElement = findElementById("preApplyButton")
 
-  def preNoticeDeleteButton:WebElement = findElementById("preDeleteButton")
+  def preNoticeClearButton:WebElement = findElementById("preClearButton")
 
   def preNoticeField:WebElement = findElementById("preNoticeField")
 
   def postNoticeApplyButton:WebElement = findElementById("postApplyButton")
 
-  def postNoticeDeleteButton:WebElement = findElementById("postDeleteButton")
+  def postNoticeClearButton:WebElement = findElementById("postClearButton")
 
   def postNoticeField:WebElement = findElementById("postNoticeField")
-  
+
+  def preTab:WebElement = findElementById("preTab")
+
+  def postTab:WebElement = findElementById("postTab")
+
+  def clearOkButton:WebElement = findElementById("okToClear")
+
   def clickPreApply(): Unit = {
     this.preNoticeApplyButton.click()
   }
 
-  def clickPreDelete(): Unit = {
-    this.preNoticeDeleteButton.click()
+  def clickPreClear(): Unit = {
+    this.preNoticeClearButton.click()
+    this.clearOkButton.click()
   }
 
   def populatePreNoticeField(notice:String): Unit = {
@@ -41,8 +48,17 @@ case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice
     this.postNoticeApplyButton.click()
   }
 
-  def clickPostDelete(): Unit = {
-    this.postNoticeDeleteButton.click()
+  def clickPostClear(): Unit = {
+    this.postNoticeClearButton.click()
+    this.clearOkButton.click()
+  }
+
+  def clickPreTab(): Unit = {
+    this.preTab.click()
+  }
+
+  def clickPostTab(): Unit = {
+    this.postTab.click()
   }
 
   def populatePostNoticeField(notice:String): Unit = {
@@ -54,4 +70,5 @@ case class LoginNoticePage(ctx: PageContext) extends NewTitledPage("Login Notice
   def getPostNoticeFieldContents:String = {
     postNoticeField.getText
   }
+
 }

--- a/Tests/src/test/scala/equellatests/pages/LoginPage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginPage.scala
@@ -2,7 +2,7 @@ package equellatests.pages
 
 import com.tle.webtests.framework.PageContext
 import equellatests.browserpage.LoadablePage
-import org.openqa.selenium.By
+import org.openqa.selenium.{By, WebElement}
 import org.openqa.selenium.support.ui.ExpectedCondition
 
 case class LoginPage(ctx: PageContext) extends LoadablePage {
@@ -27,4 +27,6 @@ case class LoginPage(ctx: PageContext) extends LoadablePage {
   }
 
   def pageBy = By.id("_logonButton")
+
+  def loginNotice:WebElement = findElementById("loginNotice")
 }

--- a/Tests/src/test/scala/equellatests/pages/LoginPage.scala
+++ b/Tests/src/test/scala/equellatests/pages/LoginPage.scala
@@ -28,5 +28,9 @@ case class LoginPage(ctx: PageContext) extends LoadablePage {
 
   def pageBy = By.id("_logonButton")
 
-  def loginNotice:WebElement = findElementById("loginNotice")
+  private def loginNotice:WebElement = findElementById("loginNotice")
+
+  def loginNoticeExists:Boolean = {
+    loginNotice.isDisplayed
+  }
 }

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -8,14 +8,14 @@ import org.scalacheck.Prop.forAll
 
 object LoginNoticeMenuProperties extends ShotProperties ("Login Notice Menu Properties"){
 
-  property("plaintext notice creation") = forAll { (w1: String) =>
+  property("plaintext notice creation") = forAll { w1: String =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1}"
       page.populateNoticeField(notice)
       page.clickApply()
       page.load()
-      Prop(page.getNoticeField==notice).label("Notice: " + notice + ", NoticeField: " + page.getNoticeField)
+      Prop(page.getNoticeFieldContents==notice).label("Notice: " + notice + ", NoticeField: " + page.getNoticeFieldContents)
     }
   }
 

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -7,6 +7,7 @@ import org.scalacheck.Prop
 import org.scalacheck.Prop.forAll
 
 object LoginNoticeMenuProperties extends ShotProperties ("Login Notice Menu Properties"){
+
   property("plaintext notice creation") = forAll { (w1: String) =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
@@ -17,4 +18,5 @@ object LoginNoticeMenuProperties extends ShotProperties ("Login Notice Menu Prop
       Prop(page.getNoticeField==notice).label("Notice: " + notice + ", NoticeField: " + page.getNoticeField)
     }
   }
+
 }

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -14,10 +14,8 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1.word}"
-      page.populatePreNoticeField(notice)
-      page.clickPreApply()
+      page.setPreLoginNotice(notice)
       page.load()
-      page.waitForLoad()
       Prop(page.getPreNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPreNoticeFieldContents)
     }
   }
@@ -25,13 +23,10 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
   property("post login notice creation") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
-      page.clickPostTab()
       val notice = s"${w1.word}"
-      page.populatePostNoticeField(notice)
-      page.clickPostApply()
+      page.setPostLoginNotice(notice)
       page.load()
-      page.waitForLoad()
-      page.clickPostTab()
+      page.gotoPostNoticeTab()
       Prop(page.getPostNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPostNoticeFieldContents)
     }
   }
@@ -40,11 +35,9 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1.word}"
-      page.populatePreNoticeField(notice)
-      page.clickPreApply()
-      page.clickPreClear()
+      page.setPreLoginNotice(notice)
+      page.clearPreLoginNotice()
       page.load()
-      page.waitForLoad()
       Prop(page.getPreNoticeFieldContents == "")
     }
   }
@@ -53,16 +46,11 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1.word}"
-      page.clickPostTab()
-      page.populatePostNoticeField(notice)
-      page.clickPostApply()
+      page.setPostLoginNotice(notice)
       page.load()
-      page.waitForLoad()
-      page.clickPostTab()
-      page.clickPostClear()
+      page.clearPostLoginNotice()
       page.load()
-      page.waitForLoad()
-      page.clickPostTab()
+      page.gotoPostNoticeTab()
       Prop(page.getPostNoticeFieldContents == "")
     }
   }
@@ -70,12 +58,9 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
   property("prove existence on login page after creation") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
-      page.waitForLoad()
       val notice = s"${w1.word}"
-      page.populatePreNoticeField(notice)
-      page.clickPreApply()
+      page.setPreLoginNotice(notice)
       page.load()
-      page.waitForLoad()
       val page2 = LoginPage(context).load()
       Prop(page2.findElementO(By.id("loginNotice")).get.getText == notice)
     }
@@ -84,15 +69,11 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
   property("prove non-existence on login page after clear") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
-      page.waitForLoad()
       val notice = s"${w1.word}"
-      page.populatePreNoticeField(notice)
-      page.clickPreApply()
+      page.setPreLoginNotice(notice)
       page.load()
-      page.waitForLoad()
-      page.clickPreClear()
+      page.clearPreLoginNotice()
       page.load()
-      page.waitForLoad()
       val page2 = LoginPage(context).load()
       Prop(page2.findElementO(By.id("loginNotice")).isEmpty)
     }

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -1,0 +1,20 @@
+package equellatests.tests
+
+import equellatests.ShotProperties
+import equellatests.instgen.fiveo.autoTestLogon
+import equellatests.pages.LoginNoticePage
+import org.scalacheck.Prop
+import org.scalacheck.Prop.forAll
+
+object LoginNoticeMenuProperties extends ShotProperties ("Login Notice Menu Properties"){
+  property("plaintext notice creation") = forAll { (w1: String) =>
+    withLogon(autoTestLogon) { context =>
+      val page = LoginNoticePage(context).load()
+      val notice = s"${w1}"
+      page.populateNoticeField(notice)
+      page.clickApply()
+      page.load()
+      Prop(page.getNoticeField==notice).label("Notice: " + notice + ", NoticeField: " + page.getNoticeField)
+    }
+  }
+}

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -17,6 +17,7 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
       page.populatePreNoticeField(notice)
       page.clickPreApply()
       page.load()
+      page.waitForLoad()
       Prop(page.getPreNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPreNoticeFieldContents)
     }
   }
@@ -29,6 +30,7 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
       page.populatePostNoticeField(notice)
       page.clickPostApply()
       page.load()
+      page.waitForLoad()
       page.clickPostTab()
       Prop(page.getPostNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPostNoticeFieldContents)
     }
@@ -42,6 +44,7 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
       page.clickPreApply()
       page.clickPreClear()
       page.load()
+      page.waitForLoad()
       Prop(page.getPreNoticeFieldContents == "")
     }
   }
@@ -54,9 +57,11 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
       page.populatePostNoticeField(notice)
       page.clickPostApply()
       page.load()
+      page.waitForLoad()
       page.clickPostTab()
       page.clickPostClear()
       page.load()
+      page.waitForLoad()
       page.clickPostTab()
       Prop(page.getPostNoticeFieldContents == "")
     }
@@ -65,10 +70,12 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
   property("prove existence on login page after creation") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
+      page.waitForLoad()
       val notice = s"${w1.word}"
       page.populatePreNoticeField(notice)
       page.clickPreApply()
       page.load()
+      page.waitForLoad()
       val page2 = LoginPage(context).load()
       Prop(page2.findElementO(By.id("loginNotice")).get.getText == notice)
     }
@@ -77,12 +84,15 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
   property("prove non-existence on login page after clear") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
+      page.waitForLoad()
       val notice = s"${w1.word}"
       page.populatePreNoticeField(notice)
       page.clickPreApply()
       page.load()
+      page.waitForLoad()
       page.clickPreClear()
       page.load()
+      page.waitForLoad()
       val page2 = LoginPage(context).load()
       Prop(page2.findElementO(By.id("loginNotice")).isEmpty)
     }

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -1,21 +1,86 @@
 package equellatests.tests
 
 import equellatests.ShotProperties
+import equellatests.domain.RandomWord
 import equellatests.instgen.fiveo.autoTestLogon
-import equellatests.pages.LoginNoticePage
+import equellatests.pages.{LoginNoticePage, LoginPage}
+import org.openqa.selenium.By
 import org.scalacheck.Prop
 import org.scalacheck.Prop.forAll
 
-object LoginNoticeMenuProperties extends ShotProperties ("Login Notice Menu Properties"){
+object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Properties") {
 
-  property("plaintext notice creation") = forAll { w1: String =>
+  property("pre login notice creation") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
-      val notice = s"${w1}"
-      page.populateNoticeField(notice)
-      page.clickApply()
+      val notice = s"${w1.word}"
+      page.populatePreNoticeField(notice)
+      page.clickPreApply()
       page.load()
-      Prop(page.getNoticeFieldContents==notice).label("Notice: " + notice + ", NoticeField: " + page.getNoticeFieldContents)
+      Prop(page.getPreNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPreNoticeFieldContents)
+    }
+  }
+
+  property("post login notice creation") = forAll { w1: RandomWord =>
+    withLogon(autoTestLogon) { context =>
+      val page = LoginNoticePage(context).load()
+      val notice = s"${w1.word}"
+      page.populatePostNoticeField(notice)
+      page.clickPostApply()
+      page.load()
+      Prop(page.getPostNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPostNoticeFieldContents)
+    }
+  }
+
+  property("pre login notice deletion") = forAll { w1: RandomWord =>
+    withLogon(autoTestLogon) { context =>
+      val page = LoginNoticePage(context).load()
+      val notice = s"${w1.word}"
+      page.populatePreNoticeField(notice)
+      page.clickPreApply()
+      page.load()
+      page.clickPreDelete()
+      page.load()
+      Prop(page.getPreNoticeFieldContents == "")
+    }
+  }
+
+  property("post login notice deletion") = forAll { w1: RandomWord =>
+    withLogon(autoTestLogon) { context =>
+      val page = LoginNoticePage(context).load()
+      val notice = s"${w1.word}"
+      page.populatePostNoticeField(notice)
+      page.clickPostApply()
+      page.load()
+      page.clickPostDelete()
+      page.load()
+      Prop(page.getPostNoticeFieldContents == "")
+    }
+  }
+
+  property("prove existence on login page after creation") = forAll { w1: RandomWord =>
+    withLogon(autoTestLogon) { context =>
+      val page = LoginNoticePage(context).load()
+      val notice = s"${w1.word}"
+      page.populatePreNoticeField(notice)
+      page.clickPreApply()
+      page.load()
+      val page2 = LoginPage(context).load()
+      Prop(page2.findElementO(By.id("loginNotice")).get.getText == notice)
+    }
+  }
+
+  property("prove non-existence on login page after deletion") = forAll { w1: RandomWord =>
+    withLogon(autoTestLogon) { context =>
+      val page = LoginNoticePage(context).load()
+      val notice = s"${w1.word}"
+      page.populatePreNoticeField(notice)
+      page.clickPreApply()
+      page.load()
+      page.clickPreDelete()
+      page.load()
+      val page2 = LoginPage(context).load()
+      Prop(page2.findElementO(By.id("loginNotice")).isEmpty)
     }
   }
 

--- a/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
+++ b/Tests/src/test/scala/equellatests/tests/LoginNoticeMenuProperties.scala
@@ -24,36 +24,40 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
   property("post login notice creation") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
+      page.clickPostTab()
       val notice = s"${w1.word}"
       page.populatePostNoticeField(notice)
       page.clickPostApply()
       page.load()
+      page.clickPostTab()
       Prop(page.getPostNoticeFieldContents == notice).label("Notice: " + notice + ", NoticeField: " + page.getPostNoticeFieldContents)
     }
   }
 
-  property("pre login notice deletion") = forAll { w1: RandomWord =>
+  property("pre login notice clear") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1.word}"
       page.populatePreNoticeField(notice)
       page.clickPreApply()
-      page.load()
-      page.clickPreDelete()
+      page.clickPreClear()
       page.load()
       Prop(page.getPreNoticeFieldContents == "")
     }
   }
 
-  property("post login notice deletion") = forAll { w1: RandomWord =>
+  property("post login notice clear") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1.word}"
+      page.clickPostTab()
       page.populatePostNoticeField(notice)
       page.clickPostApply()
       page.load()
-      page.clickPostDelete()
+      page.clickPostTab()
+      page.clickPostClear()
       page.load()
+      page.clickPostTab()
       Prop(page.getPostNoticeFieldContents == "")
     }
   }
@@ -70,18 +74,17 @@ object LoginNoticeMenuProperties extends ShotProperties("Login Notice Menu Prope
     }
   }
 
-  property("prove non-existence on login page after deletion") = forAll { w1: RandomWord =>
+  property("prove non-existence on login page after clear") = forAll { w1: RandomWord =>
     withLogon(autoTestLogon) { context =>
       val page = LoginNoticePage(context).load()
       val notice = s"${w1.word}"
       page.populatePreNoticeField(notice)
       page.clickPreApply()
       page.load()
-      page.clickPreDelete()
+      page.clickPreClear()
       page.load()
       val page2 = LoginPage(context).load()
       Prop(page2.findElementO(By.id("loginNotice")).isEmpty)
     }
   }
-
 }

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,8 +17,8 @@ phases:
   build:
     commands:
       - sbt -no-colors installEquella startEquella
-      - sbt -no-colors configureInstall setupForTests ${OTHER_TESTS}
-      - sbt -no-colors Tests/test
+      - sbt -no-colors configureInstall setupForTests Tests/test
+      - sbt -no-colors ${OTHER_TESTS}
   post_build:
     commands:
       - sbt -no-colors coverageReport ; publishTestResults


### PR DESCRIPTION
Autotests in ScalaCheck for the creation, deletion, existence and non-existence of a basic login notice from [this issue](https://github.com/equella/Equella/issues/660).

**Related Pull Requests:**
[Create notice PR](https://github.com/equella/Equella/pull/720)
[Delete notice PR](https://github.com/equella/Equella/pull/723)
[Migrate old notice setting into new menu PR](https://github.com/equella/Equella/pull/729)
[View notice PR](https://github.com/equella/Equella/pull/734)
